### PR TITLE
Bump cortex-m dependency to v0.6.2

### DIFF
--- a/panic_rtt/Cargo.toml
+++ b/panic_rtt/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/wez/jlink_rtt"
 readme = "../README.md"
 
 [dependencies]
-cortex-m = "~0.5"
+cortex-m = "0.6.2"
 
 [dependencies.jlink_rtt]
 version = "~0.1"


### PR DESCRIPTION
The v0.5.10 version of cortex-m fails to compile. Increasing to the current, latest version fixes the problem. It doesn't appear to introduce any new issues.